### PR TITLE
chore: initialize Conductor project artifacts

### DIFF
--- a/conductor/code_styleguides/java.md
+++ b/conductor/code_styleguides/java.md
@@ -1,0 +1,84 @@
+# Java Style Guide
+
+Applies to all Java source files in this project (Java 21, compiled with `-parameters`).
+
+## Formatting
+
+- **Indentation**: 4 spaces, no tabs.
+- **Line length**: 120 characters max.
+- **Braces**: Allman-adjacent (opening brace on same line as declaration).
+- **Blank lines**: One blank line between methods; two between top-level declarations.
+- **Trailing whitespace**: Not permitted.
+- **File encoding**: UTF-8 (enforced via `options.encoding = "UTF-8"` in Gradle).
+
+## Naming
+
+| Element | Convention | Example |
+|---------|-----------|---------|
+| Classes / Interfaces | UpperCamelCase | `RedisClientFactory` |
+| Methods / Variables | lowerCamelCase | `buildConnection()` |
+| Constants | UPPER_SNAKE_CASE | `DEFAULT_TIMEOUT_MS` |
+| Packages | all lowercase, dot-separated | `org.carl.infrastructure.redis` |
+| Test classes | suffix `Test` | `RedisClientFactoryTest` |
+
+## Imports
+
+- No wildcard imports (`import java.util.*` is forbidden).
+- Static imports allowed for test assertions (`assertThat`, `assertEquals`).
+- Import order: Java standard library → Jakarta/Javax → third-party → internal (`org.carl`).
+
+## Module Structure
+
+Every module must follow this layout:
+
+```
+src/
+  main/
+    java/org/carl/infrastructure/<module>/
+      api/          # Public interfaces and DTOs (stable contract)
+      impl/         # Internal implementations (not part of public API)
+      config/       # Configuration classes
+  test/
+    java/org/carl/infrastructure/<module>/
+```
+
+## API Visibility
+
+- Public interfaces live under `api/` and are part of the public contract.
+- Implementation classes under `impl/` must be package-private or annotated `@Internal` where a public modifier is unavoidable.
+- Do not expose concrete implementation types in method signatures — use the interface type.
+
+## Quarkus-Specific Rules (Quarkus modules only)
+
+- Inject dependencies via `@Inject` (CDI), not constructor injection, unless the class is not a CDI bean.
+- Configuration must use `@ConfigMapping` or `@ConfigProperty`; no hardcoded values.
+- Startup validation goes in a method annotated `@Observes StartupEvent`; never in a constructor.
+- All CDI beans used in tests must be annotated `@QuarkusTest` with `@InjectMock` for external dependencies.
+
+## Testing
+
+- Every public API method requires at least one unit test.
+- Test method names follow the pattern: `should_<expected>_when_<condition>`.
+- Use JUnit 5 (`@Test`, `@BeforeEach`, `@AfterEach`).
+- Quarkus modules use `@QuarkusTest`; standalone modules use plain JUnit 5.
+- No `Thread.sleep()` in tests — use `Awaitility` for async assertions.
+- Mocking: Mockito for unit tests; `@InjectMock` / `@QuarkusMock` for Quarkus integration tests.
+
+## Error Handling
+
+- Prefer checked exceptions for recoverable conditions at module boundaries.
+- Use unchecked exceptions (`RuntimeException` subclasses) for programming errors.
+- Never swallow exceptions silently; log at minimum `WARN` before rethrowing or recovering.
+- Log with SLF4J via `infrastructure-component-log` — do not use `System.out` or `java.util.logging` directly.
+
+## Javadoc
+
+- All public interfaces and methods in `api/` packages must have Javadoc.
+- Describe *what* the method does and any non-obvious constraints. Skip trivial getters.
+- `@param` and `@return` tags are required when their meaning is not self-evident from the name.
+
+## Dependency Rules
+
+- Standalone modules: zero Quarkus dependencies (even optional/provided scope).
+- Quarkus modules: may depend on standalone modules; use `implementation(enforcedPlatform(libs.quarkus.platform.bom))` for version alignment.
+- Add dependencies to version catalogs (`libs.versions.toml`) rather than hardcoding versions in module `build.gradle.kts`.

--- a/conductor/code_styleguides/kotlin.md
+++ b/conductor/code_styleguides/kotlin.md
@@ -1,0 +1,57 @@
+# Kotlin Style Guide
+
+Applies to Kotlin files in this project — currently Gradle build scripts (`build.gradle.kts`, `settings.gradle.kts`).
+
+## General
+
+- Follow [Kotlin Coding Conventions](https://kotlinlang.org/docs/coding-conventions.html) as the baseline.
+- `kotlin.code.style=official` is set in `gradle.properties` — IDEs should pick this up automatically.
+
+## Gradle Build Scripts
+
+### Formatting
+
+- **Indentation**: 4 spaces, no tabs.
+- **Line length**: 120 characters max.
+- Each `dependencies {}` block groups entries in this order:
+  1. `api(...)` declarations
+  2. `implementation(...)` declarations
+  3. `testImplementation(...)` declarations
+  4. Blank line separating each group.
+
+### Plugin Declarations
+
+- Use the `plugins {}` block at the top of every `build.gradle.kts`.
+- Pin versions for non-BOM plugins explicitly: `id("some.plugin") version "x.y.z"`.
+- Do not apply plugins via the legacy `apply plugin: "..."` syntax.
+
+### Dependency Management
+
+- Declare all shared versions in the version catalog (`gradle/libs.versions.toml`).
+- Reference catalog entries via `libs.<alias>` — do not hardcode version strings in module build files.
+- Use `enforcedPlatform` only for the Quarkus BOM; avoid it elsewhere to prevent version conflicts.
+- Prefer `api(...)` for dependencies that are part of a module's public API; use `implementation(...)` for internal dependencies.
+
+### Naming Conventions
+
+| Element | Convention | Example |
+|---------|-----------|---------|
+| Variables / vals | lowerCamelCase | `quarkusVersion` |
+| Extension functions | lowerCamelCase | `configureJavaToolchain()` |
+| Constants (top-level) | UPPER_SNAKE_CASE | `DEFAULT_JVM_ARGS` |
+
+### Task Configuration
+
+- Use `tasks.named<TaskType>("taskName") { }` rather than `tasks.getByName(...)` to avoid eager resolution.
+- Disable tasks explicitly with `enabled = false` rather than removing them.
+
+### Comments
+
+- Write comments only when the build logic is non-obvious (e.g. why a workaround exists).
+- Do not comment out code — remove it. Use git history if rollback is needed.
+
+## Version Catalog (`libs.versions.toml`)
+
+- Group versions under `[versions]`, libraries under `[libraries]`, plugins under `[plugins]`.
+- Use kebab-case for alias names: `quarkus-platform-bom`, `infrastructure-component-redis`.
+- Keep the catalog sorted alphabetically within each section.

--- a/conductor/index.md
+++ b/conductor/index.md
@@ -1,0 +1,19 @@
+# Conductor — Infrastructure Components
+
+Navigation hub for project context.
+
+## Quick Links
+
+- [Product Definition](./product.md)
+- [Product Guidelines](./product-guidelines.md)
+- [Tech Stack](./tech-stack.md)
+- [Workflow](./workflow.md)
+- [Tracks](./tracks.md)
+
+## Active Tracks
+
+<!-- Auto-populated by /conductor:new-track -->
+
+## Getting Started
+
+Run `/conductor:new-track` to create your first feature track.

--- a/conductor/product-guidelines.md
+++ b/conductor/product-guidelines.md
@@ -1,0 +1,30 @@
+# Product Guidelines
+
+## Voice and Tone
+
+**Professional and technical.**
+
+Documentation, API Javadoc, error messages, and log output should be precise and unambiguous. Prefer exact terminology over casual language. Assume the reader is a competent backend engineer.
+
+## Design Principles
+
+### Developer Experience Focused
+
+Every API surface, configuration option, and error message must reduce friction for the consuming developer:
+
+- Sensible defaults — modules work out-of-the-box with zero mandatory configuration where possible.
+- Explicit over implicit — when behaviour deviates from defaults, make it obvious via clear naming and documentation.
+- Fail fast and loudly — misconfiguration should surface at startup, not at runtime under load.
+- Consistent patterns — standalone and Quarkus modules should feel like the same library; share interfaces and DTOs where possible.
+
+## Module Boundary Rules
+
+- **Quarkus modules** may depend on standalone modules, never the reverse.
+- Standalone modules must not introduce a transitive Quarkus dependency (even optional).
+- Each module should have a single, clearly stated responsibility.
+
+## API Design Standards
+
+- Prefer interface-based APIs over concrete class exposure.
+- Mark implementation classes `@Internal` (or package-private) where they are not intended for direct use.
+- Breaking changes to public APIs require a version bump and a migration note in the module's changelog.

--- a/conductor/product.md
+++ b/conductor/product.md
@@ -1,0 +1,31 @@
+# Product Definition
+
+## Project Name
+
+Infrastructure Components
+
+## Description
+
+A multi-module Java library that packages Quarkus integrations and standalone utilities for backend services.
+
+## Problem Statement
+
+Microservice teams repeatedly reimplement the same infrastructure concerns (auth, caching, messaging, persistence) — this library centralizes and standardizes those solutions.
+
+## Target Users
+
+Internal platform/infrastructure teams maintaining shared service capabilities.
+
+## Key Goals
+
+1. Provide Quarkus-integrated components for Quarkus-based microservices — delivered as Quarkus extensions that plug cleanly into the Quarkus CDI lifecycle.
+2. Provide standalone modules usable in any Java project without a Quarkus dependency — framework-agnostic libraries that can be consumed by non-Quarkus services.
+
+## Module Structure
+
+The library is split into two categories:
+
+| Category | Description |
+|----------|-------------|
+| **Quarkus Integration Modules** (`infrastructure-component-quarkus/`) | Depend on Quarkus; used as Quarkus extensions |
+| **Standalone Library Modules** | No Quarkus dependency; usable in any Java project |

--- a/conductor/setup_state.json
+++ b/conductor/setup_state.json
@@ -1,0 +1,51 @@
+{
+  "status": "complete",
+  "project_type": "brownfield",
+  "current_section": "done",
+  "current_question": 0,
+  "completed_sections": ["product", "guidelines", "tech_stack", "workflow", "styleguides"],
+  "answers": {
+    "project_name": "Infrastructure Components",
+    "description": "A multi-module Java library that packages Quarkus integrations and standalone utilities for backend services",
+    "problem_statement": "Microservice teams repeatedly reimplement the same infrastructure concerns (auth, caching, messaging, persistence) — this library centralizes and standardizes those solutions.",
+    "target_users": "Internal platform/infrastructure teams maintaining shared service capabilities.",
+    "key_goals": [
+      "Provide Quarkus-integrated components for Quarkus-based microservices",
+      "Provide standalone modules usable in any Java project without a Quarkus dependency"
+    ],
+    "voice_tone": "Professional and technical",
+    "design_principles": ["Developer experience focused"],
+    "language": "Java 21",
+    "build_tool": "Gradle (Kotlin DSL)",
+    "framework": "Quarkus 3.19.3",
+    "database": "PostgreSQL (JDBC + JOOQ)",
+    "messaging": "Apache Pulsar",
+    "cache": "Redis (Vert.x), Quarkus Cache",
+    "search": "Elasticsearch",
+    "auth": "OIDC / Keycloak",
+    "workflow_engine": "Temporal",
+    "service_discovery": "Consul + Stork",
+    "rpc": "Vert.x gRPC",
+    "observability": "OpenTelemetry",
+    "infrastructure": "Self-hosted / Docker or Kubernetes",
+    "tdd_strictness": "Strict — tests required before implementation",
+    "commit_strategy": "Conventional Commits",
+    "code_review": "Required for all changes",
+    "verification_checkpoints": "After each task completion",
+    "styleguide_languages": ["Java", "Kotlin"],
+    "existing_conventions": "Yes, incorporate existing Gradle/Java conventions"
+  },
+  "files_created": [
+    "conductor/setup_state.json",
+    "conductor/index.md",
+    "conductor/product.md",
+    "conductor/product-guidelines.md",
+    "conductor/tech-stack.md",
+    "conductor/workflow.md",
+    "conductor/tracks.md",
+    "conductor/code_styleguides/java.md",
+    "conductor/code_styleguides/kotlin.md"
+  ],
+  "started_at": "2026-05-03T00:00:00Z",
+  "last_updated": "2026-05-03T00:00:00Z"
+}

--- a/conductor/tech-stack.md
+++ b/conductor/tech-stack.md
@@ -1,0 +1,118 @@
+# Tech Stack
+
+## Language
+
+| Language | Version |
+|----------|---------|
+| Java | 21 (LTS) |
+| Kotlin | (Gradle build scripts only) |
+
+Java toolchain is pinned via `java.toolchain.languageVersion = JavaLanguageVersion.of(21)` in the root `build.gradle.kts`.
+
+## Build Tool
+
+| Tool | Version |
+|------|---------|
+| Gradle | 8.x (Kotlin DSL) |
+| Gradle parallel builds | Enabled (`org.gradle.parallel=true`) |
+| Gradle build cache | Enabled (`org.gradle.caching=true`) |
+
+## Framework
+
+| Framework | Version |
+|-----------|---------|
+| Quarkus | 3.19.3 |
+
+Quarkus BOM is used as the enforced platform for all dependency versions within Quarkus-integrated modules.
+
+## Persistence
+
+| Component | Details |
+|-----------|---------|
+| Database | PostgreSQL |
+| Quarkus integration | `quarkus-jdbc-postgresql`, `quarkus-agroal` |
+| Standalone ORM | JOOQ (`infrastructure-component-persistence-jooq`) |
+
+## Messaging
+
+| Component | Details |
+|-----------|---------|
+| Broker | Apache Pulsar |
+| Quarkus integration | `quarkus-pulsar` (`infrastructure-component-quarkus/mq`) |
+| Standalone API | `infrastructure-component-mq-api` (broker-agnostic interface) |
+| Standalone impl | `infrastructure-component-mq-pulsar` |
+
+## Caching
+
+| Component | Details |
+|-----------|---------|
+| Distributed cache | Redis via Vert.x Redis client (`infrastructure-component-redis`) |
+| Quarkus cache | `quarkus-cache`, `quarkus-redis` (`infrastructure-component-quarkus/cache`) |
+
+## Search
+
+| Component | Details |
+|-----------|---------|
+| Engine | Elasticsearch |
+| Integration | `quarkus-elasticsearch` (`infrastructure-component-quarkus/search`) |
+
+## Auth & Authorization
+
+| Component | Details |
+|-----------|---------|
+| Protocol | OIDC |
+| Provider | Keycloak |
+| Integration | `quarkus-oidc`, `quarkus-keycloak` (`infrastructure-component-quarkus/authorization`) |
+| Policy | `infrastructure-component-pdp` (standalone Policy Decision Point) |
+
+## Workflow & State
+
+| Component | Details |
+|-----------|---------|
+| Workflow engine | Temporal (`quarkus-temporal`, `infrastructure-component-quarkus/workflow`) |
+| State machine | `infrastructure-component-statemachine` (standalone) |
+| Rule engine | `infrastructure-component-rule-engine` (standalone) |
+
+## Service Discovery
+
+| Component | Details |
+|-----------|---------|
+| Registry | Consul |
+| Load balancing | Stork (`consul-stork`) |
+| Integration | `infrastructure-component-quarkus/discover` |
+
+## RPC
+
+| Component | Details |
+|-----------|---------|
+| Framework | Vert.x gRPC |
+| Proto codegen | `vertx-grpc-protoc-plugin2:4.5.13` |
+| gRPC modules | `infrastructure-component-qdrant-grpc`, `infrastructure-component-embedding-grpc` |
+
+## Observability
+
+| Component | Details |
+|-----------|---------|
+| Tracing/Metrics | OpenTelemetry (`quarkus-opentelemetry`) |
+| Integration | `infrastructure-component-quarkus/metrics` |
+
+## Shared Utilities
+
+| Module | Purpose |
+|--------|---------|
+| `infrastructure-component-dto` | Base DTOs: Command, Query, Response, PageQuery |
+| `infrastructure-component-log` | Unified logging (auto-adapts SLF4J / JBoss Logging) |
+| `infrastructure-component-utils` | General utilities (String, Collection, DAG); depends on Guava, commons-collections4 |
+
+## Infrastructure / Deployment
+
+- Self-hosted via Docker
+- Kubernetes (internal cluster)
+- Native image builds supported via Quarkus Mandrel builder (`ubi9-quarkus-mandrel-builder-image:jdk-21`)
+
+## Group & Version
+
+```
+group = org.carl
+version = 1.0-BATE
+```

--- a/conductor/tracks.md
+++ b/conductor/tracks.md
@@ -1,0 +1,6 @@
+# Tracks Registry
+
+| Status | Track ID | Title | Created | Updated |
+| ------ | -------- | ----- | ------- | ------- |
+
+<!-- Tracks registered by /conductor:new-track -->

--- a/conductor/workflow.md
+++ b/conductor/workflow.md
@@ -1,0 +1,64 @@
+# Workflow
+
+## TDD Policy
+
+**Strict — tests required before implementation.**
+
+- Write the test first. No implementation code is merged without a corresponding test written beforehand.
+- Unit tests cover all public API methods.
+- Integration tests are required for any module that interacts with external systems (DB, Redis, Pulsar, etc.).
+- A task is not considered complete until all tests pass (`./gradlew test`).
+
+## Commit Strategy
+
+**Conventional Commits** — all commit messages must follow the [Conventional Commits 1.0.0](https://www.conventionalcommits.org/) specification.
+
+Common types used in this project:
+
+| Type | When to use |
+|------|-------------|
+| `feat` | New module or public API addition |
+| `fix` | Bug fix in an existing module |
+| `refactor` | Code restructuring without behaviour change |
+| `test` | Adding or fixing tests |
+| `docs` | Documentation only |
+| `build` | Gradle build scripts, dependency updates |
+| `chore` | Maintenance (CI, tooling, formatting) |
+| `perf` | Performance improvement |
+
+Scope should reference the affected module, e.g. `feat(redis): add distributed lock timeout option`.
+
+Breaking changes must include `BREAKING CHANGE:` in the commit footer.
+
+## Code Review
+
+**Required for all changes.**
+
+- Every change must go through a pull request; direct pushes to `main` are not permitted.
+- At least one approval is required before merge.
+- Reviewer must verify: tests present, API boundaries respected, no unintended Quarkus dependency leakage into standalone modules.
+
+## Verification Checkpoints
+
+**After each task completion.**
+
+Before marking a task done, the implementer must:
+
+1. Run `./gradlew build` — build must succeed with no errors.
+2. Run `./gradlew test` — all tests must pass.
+3. Manually verify the change behaves as specified in the task description.
+4. Confirm no regressions in dependent modules (`./gradlew :affected-module:test`).
+
+## Task Lifecycle
+
+```
+pending → in_progress → [manual verification] → completed
+```
+
+A task moves to `in_progress` when work begins. It moves to `completed` only after verification passes. If verification fails, it stays `in_progress` until resolved.
+
+## Branch Strategy
+
+- Feature branches: `feat/<scope>-<short-description>`
+- Bug fix branches: `fix/<scope>-<short-description>`
+- Base branch for PRs: `main`


### PR DESCRIPTION
## Summary

- Adds a `conductor/` directory with foundational project context documents generated via `/conductor:setup`.
- Captures product definition, tech stack, workflow policies, and code style guides for the Infrastructure Components library.
- Provides a shared reference that future feature tracks (`/conductor:new-track`) will build on.

## What changed

| File | Purpose |
|------|---------|
| `conductor/index.md` | Navigation hub with quick links to all context docs |
| `conductor/product.md` | Project name, description, problem statement, target users, key goals |
| `conductor/product-guidelines.md` | Voice/tone, design principles, module boundary rules, API design standards |
| `conductor/tech-stack.md` | Full tech inventory: Java 21, Quarkus 3.19.3, PostgreSQL/JOOQ, Pulsar, Redis, Elasticsearch, Temporal, Consul, Vert.x gRPC, OpenTelemetry |
| `conductor/workflow.md` | TDD policy (strict), Conventional Commits, PR-required review, per-task verification checkpoints |
| `conductor/tracks.md` | Empty tracks registry (populated by `/conductor:new-track`) |
| `conductor/code_styleguides/java.md` | Java 21 style guide incorporating existing Gradle/Java conventions |
| `conductor/code_styleguides/kotlin.md` | Kotlin style guide for Gradle build scripts |
| `conductor/setup_state.json` | Setup state record (status: complete) |

## Reviewer notes

- No production code is changed — this is documentation/context only.
- The `conductor/` directory is consumed by the Claude Code Conductor workflow tooling.
- Review the tech stack and workflow docs to confirm they match team expectations before the first track is created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)