### PR TITLE
:memo: 修正 conductor 文档与仓库约定的冲突

### DIFF
--- a/conductor/code_styleguides/java.md
+++ b/conductor/code_styleguides/java.md
@@ -69,7 +69,7 @@ src/
 - Prefer checked exceptions for recoverable conditions at module boundaries.
 - Use unchecked exceptions (`RuntimeException` subclasses) for programming errors.
 - Never swallow exceptions silently; log at minimum `WARN` before rethrowing or recovering.
-- Log with SLF4J via `infrastructure-component-log` — do not use `System.out` or `java.util.logging` directly.
+- **Log exclusively via `ILogger`** (`org.carl.infrastructure.logging`) — direct use of SLF4J or JBoss Logger is forbidden. Obtain an instance with `LoggerFactory.getLogger(MyClass.class)`.
 
 ## Javadoc
 

--- a/conductor/workflow.md
+++ b/conductor/workflow.md
@@ -11,24 +11,17 @@
 
 ## Commit Strategy
 
-**Conventional Commits** — all commit messages must follow the [Conventional Commits 1.0.0](https://www.conventionalcommits.org/) specification.
+Format: `:emoji: 简短描述` — matches the repository convention defined in `AGENTS.md`.
 
-Common types used in this project:
+| Emoji | When to use |
+|-------|-------------|
+| `:sparkles:` | New feature or module |
+| `:bug:` | Bug fix |
+| `:recycle:` | Refactor (no behaviour change) |
+| `:memo:` | Documentation only |
+| `:white_check_mark:` | Tests |
 
-| Type | When to use |
-|------|-------------|
-| `feat` | New module or public API addition |
-| `fix` | Bug fix in an existing module |
-| `refactor` | Code restructuring without behaviour change |
-| `test` | Adding or fixing tests |
-| `docs` | Documentation only |
-| `build` | Gradle build scripts, dependency updates |
-| `chore` | Maintenance (CI, tooling, formatting) |
-| `perf` | Performance improvement |
-
-Scope should reference the affected module, e.g. `feat(redis): add distributed lock timeout option`.
-
-Breaking changes must include `BREAKING CHANGE:` in the commit footer.
+Example: `:sparkles: redis 分布式锁增加超时配置`
 
 ## Code Review
 


### PR DESCRIPTION
## Summary

修复 PR #8 中 Codex 指出的两处 P2 问题，使 conductor 文档与 `AGENTS.md` 中定义的仓库约定保持一致。

## Changes

**`conductor/workflow.md`**
- 将提交规范从 Conventional Commits 替换为仓库标准的 `:emoji: 简短描述` 格式，与 `AGENTS.md ## Commit` 对齐。

**`conductor/code_styleguides/java.md`**
- 将日志规范从"使用 SLF4J"改为"使用 `ILogger`（`org.carl.infrastructure.logging`）"，禁止直接使用 SLF4J/JBoss Logger，与 `AGENTS.md ## Coding Style` 对齐。

## Reviewer notes

- 纯文档变更，无生产代码改动。
- 解决 Codex review 的 [inline comment on workflow.md](https://github.com/michelleclar/Infrastructure/pull/8) 和 [inline comment on java.md](https://github.com/michelleclar/Infrastructure/pull/8)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)