### PR TITLE
:sparkles: add async HTTP client component (BAC-144)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,7 @@ slf4j = "2.0.9"
 jbossLogging = "3.5.3.Final"
 temporal = "0.1.2"
 vertx = "5.0.6"
+httpcomponentsClient5 = "5.4.1"
 [libraries]
 quarkus-platform-bom = { module = "io.quarkus.platform:quarkus-bom", version.ref = "quarkus" }
 quarkus-camel-platform-bom = { module = "io.quarkus.platform:quarkus-camel-bom", version.ref = "quarkus" }
@@ -78,6 +79,7 @@ velocity = { module = "org.apache.velocity:velocity-engine-core", version.ref = 
 
 vertx-core = { module = "io.vertx:vertx-core", version.ref = "vertx" }
 vertx-redis-client = { module = "io.vertx:vertx-redis-client", version.ref = "vertx" }
+httpcomponents-client5 = { module = "org.apache.httpcomponents.client5:httpclient5", version.ref = "httpcomponentsClient5" }
 
 guava = { module = "com.google.guava:guava", version.ref = "guava" }
 commons = { module = "org.apache.commons:commons-collections4", version.ref = "commons" }
@@ -131,6 +133,7 @@ cache = ["quarkus-cache", "quarkus-redis"]
 mq = ["quarkus-pulsar"]
 search = ["quarkus-elasticsearch"]
 utils = ["guava"]
+http = ["httpcomponents-client5"]
 protocol = ["quarkus-grpc", "quarkus-websocket"]
 #metrics = ["quarkus-observability-devservices-lgtm","quarkus-micrometer-registry-prometheus", "quarkus-opentelemetry", "quarkus-micrometer-opentelemetry"]
 metrics = ["quarkus-observability-devservices-lgtm", "quarkus-opentelemetry"]

--- a/infrastructure-component-http/build.gradle.kts
+++ b/infrastructure-component-http/build.gradle.kts
@@ -1,0 +1,34 @@
+plugins {
+    id("maven-publish")
+}
+
+publishing {
+    publications {
+        create<MavenPublication>("mavenJava") {
+            from(components["java"])
+            groupId = project.group.toString()
+            artifactId = project.name
+            version = project.version.toString()
+        }
+    }
+    repositories {
+        maven {
+            credentials {
+                username = System.getenv("ALIYUN_MAVEN_USERNAME").toString()
+                password = System.getenv("ALIYUN_MAVEN_PASSWORD").toString()
+            }
+            url = uri("https://packages.aliyun.com/659e01070cab697efe1345a8/maven/repo-wdhey")
+        }
+    }
+}
+
+dependencies {
+    implementation(libs.bundles.http)
+
+    testImplementation(platform("org.junit:junit-bom:5.10.0"))
+    testImplementation("org.junit.jupiter:junit-jupiter")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/infrastructure-component-http/src/main/java/org/carl/infrastructure/http/HttpClient.java
+++ b/infrastructure-component-http/src/main/java/org/carl/infrastructure/http/HttpClient.java
@@ -1,0 +1,11 @@
+package org.carl.infrastructure.http;
+
+import java.util.concurrent.CompletionStage;
+
+public interface HttpClient extends AutoCloseable {
+
+    CompletionStage<HttpResponse> execute(HttpRequest request);
+
+    @Override
+    void close();
+}

--- a/infrastructure-component-http/src/main/java/org/carl/infrastructure/http/HttpClientException.java
+++ b/infrastructure-component-http/src/main/java/org/carl/infrastructure/http/HttpClientException.java
@@ -1,0 +1,12 @@
+package org.carl.infrastructure.http;
+
+public class HttpClientException extends RuntimeException {
+
+    public HttpClientException(String message) {
+        super(message);
+    }
+
+    public HttpClientException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/infrastructure-component-http/src/main/java/org/carl/infrastructure/http/HttpClientFactory.java
+++ b/infrastructure-component-http/src/main/java/org/carl/infrastructure/http/HttpClientFactory.java
@@ -1,0 +1,18 @@
+package org.carl.infrastructure.http;
+
+import org.carl.infrastructure.http.apache.ApacheAsyncHttpClient;
+
+public final class HttpClientFactory {
+
+    private HttpClientFactory() {
+        throw new UnsupportedOperationException("Utility class cannot be instantiated");
+    }
+
+    public static HttpClient create() {
+        return create(HttpClientOptions.builder().build());
+    }
+
+    public static HttpClient create(HttpClientOptions options) {
+        return new ApacheAsyncHttpClient(options);
+    }
+}

--- a/infrastructure-component-http/src/main/java/org/carl/infrastructure/http/HttpClientOptions.java
+++ b/infrastructure-component-http/src/main/java/org/carl/infrastructure/http/HttpClientOptions.java
@@ -1,0 +1,90 @@
+package org.carl.infrastructure.http;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+public final class HttpClientOptions {
+
+    private final Duration connectTimeout;
+    private final Duration responseTimeout;
+    private final int maxConnections;
+    private final List<HttpInterceptor> interceptors;
+
+    private HttpClientOptions(Builder builder) {
+        this.connectTimeout = builder.connectTimeout;
+        this.responseTimeout = builder.responseTimeout;
+        this.maxConnections = builder.maxConnections;
+        this.interceptors = List.copyOf(builder.interceptors);
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public Duration getConnectTimeout() {
+        return connectTimeout;
+    }
+
+    public Duration getResponseTimeout() {
+        return responseTimeout;
+    }
+
+    public int getMaxConnections() {
+        return maxConnections;
+    }
+
+    public List<HttpInterceptor> getInterceptors() {
+        return interceptors;
+    }
+
+    public static final class Builder {
+
+        private Duration connectTimeout = Duration.ofSeconds(10);
+        private Duration responseTimeout = Duration.ofSeconds(30);
+        private int maxConnections = 100;
+        private final List<HttpInterceptor> interceptors = new ArrayList<>();
+
+        public Builder connectTimeout(Duration connectTimeout) {
+            this.connectTimeout = requirePositive(connectTimeout, "connectTimeout");
+            return this;
+        }
+
+        public Builder responseTimeout(Duration responseTimeout) {
+            this.responseTimeout = requirePositive(responseTimeout, "responseTimeout");
+            return this;
+        }
+
+        public Builder maxConnections(int maxConnections) {
+            if (maxConnections <= 0) {
+                throw new IllegalArgumentException("maxConnections must be positive");
+            }
+            this.maxConnections = maxConnections;
+            return this;
+        }
+
+        public Builder addInterceptor(HttpInterceptor interceptor) {
+            this.interceptors.add(Objects.requireNonNull(interceptor, "interceptor"));
+            return this;
+        }
+
+        public Builder interceptors(List<HttpInterceptor> interceptors) {
+            this.interceptors.clear();
+            this.interceptors.addAll(Objects.requireNonNull(interceptors, "interceptors"));
+            return this;
+        }
+
+        public HttpClientOptions build() {
+            return new HttpClientOptions(this);
+        }
+
+        private static Duration requirePositive(Duration duration, String name) {
+            Objects.requireNonNull(duration, name);
+            if (duration.isZero() || duration.isNegative()) {
+                throw new IllegalArgumentException(name + " must be positive");
+            }
+            return duration;
+        }
+    }
+}

--- a/infrastructure-component-http/src/main/java/org/carl/infrastructure/http/HttpCompletionContext.java
+++ b/infrastructure-component-http/src/main/java/org/carl/infrastructure/http/HttpCompletionContext.java
@@ -1,0 +1,28 @@
+package org.carl.infrastructure.http;
+
+import java.util.Optional;
+
+public final class HttpCompletionContext {
+
+    private final HttpRequest request;
+    private final HttpResponse response;
+    private final Throwable error;
+
+    public HttpCompletionContext(HttpRequest request, HttpResponse response, Throwable error) {
+        this.request = request;
+        this.response = response;
+        this.error = error;
+    }
+
+    public HttpRequest getRequest() {
+        return request;
+    }
+
+    public Optional<HttpResponse> getResponse() {
+        return Optional.ofNullable(response);
+    }
+
+    public Optional<Throwable> getError() {
+        return Optional.ofNullable(error);
+    }
+}

--- a/infrastructure-component-http/src/main/java/org/carl/infrastructure/http/HttpErrorContext.java
+++ b/infrastructure-component-http/src/main/java/org/carl/infrastructure/http/HttpErrorContext.java
@@ -1,0 +1,20 @@
+package org.carl.infrastructure.http;
+
+public final class HttpErrorContext {
+
+    private final HttpRequest request;
+    private final Throwable error;
+
+    public HttpErrorContext(HttpRequest request, Throwable error) {
+        this.request = request;
+        this.error = error;
+    }
+
+    public HttpRequest getRequest() {
+        return request;
+    }
+
+    public Throwable getError() {
+        return error;
+    }
+}

--- a/infrastructure-component-http/src/main/java/org/carl/infrastructure/http/HttpInterceptor.java
+++ b/infrastructure-component-http/src/main/java/org/carl/infrastructure/http/HttpInterceptor.java
@@ -1,0 +1,35 @@
+package org.carl.infrastructure.http;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+public interface HttpInterceptor {
+
+    default CompletionStage<Void> beforeRequest(HttpRequestContext context) {
+        return completed();
+    }
+
+    default CompletionStage<Void> beforeSend(HttpRequestContext context) {
+        return completed();
+    }
+
+    default CompletionStage<Void> afterResponseHeaders(HttpResponseContext context) {
+        return completed();
+    }
+
+    default CompletionStage<Void> afterResponseBody(HttpResponseContext context) {
+        return completed();
+    }
+
+    default CompletionStage<Void> onError(HttpErrorContext context) {
+        return completed();
+    }
+
+    default CompletionStage<Void> afterCompletion(HttpCompletionContext context) {
+        return completed();
+    }
+
+    private static CompletionStage<Void> completed() {
+        return CompletableFuture.completedFuture(null);
+    }
+}

--- a/infrastructure-component-http/src/main/java/org/carl/infrastructure/http/HttpRequest.java
+++ b/infrastructure-component-http/src/main/java/org/carl/infrastructure/http/HttpRequest.java
@@ -1,0 +1,172 @@
+package org.carl.infrastructure.http;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+public final class HttpRequest {
+
+    private final String method;
+    private final URI uri;
+    private final Map<String, List<String>> headers;
+    private final Map<String, List<String>> queryParams;
+    private final byte[] body;
+    private final String contentType;
+    private final Duration timeout;
+
+    private HttpRequest(Builder builder) {
+        this.method = builder.method;
+        this.uri = builder.uri;
+        this.headers = copyMultiMap(builder.headers);
+        this.queryParams = copyMultiMap(builder.queryParams);
+        this.body = builder.body == null ? null : builder.body.clone();
+        this.contentType = builder.contentType;
+        this.timeout = builder.timeout;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static Builder get(String uri) {
+        return builder().method("GET").uri(uri);
+    }
+
+    public static Builder post(String uri) {
+        return builder().method("POST").uri(uri);
+    }
+
+    public static Builder put(String uri) {
+        return builder().method("PUT").uri(uri);
+    }
+
+    public static Builder delete(String uri) {
+        return builder().method("DELETE").uri(uri);
+    }
+
+    public String getMethod() {
+        return method;
+    }
+
+    public URI getUri() {
+        return uri;
+    }
+
+    public Map<String, List<String>> getHeaders() {
+        return headers;
+    }
+
+    public Map<String, List<String>> getQueryParams() {
+        return queryParams;
+    }
+
+    public byte[] getBody() {
+        return body == null ? null : body.clone();
+    }
+
+    public String getContentType() {
+        return contentType;
+    }
+
+    public Duration getTimeout() {
+        return timeout;
+    }
+
+    public boolean hasBody() {
+        return body != null;
+    }
+
+    private static Map<String, List<String>> copyMultiMap(Map<String, List<String>> source) {
+        Map<String, List<String>> copy = new LinkedHashMap<>();
+        source.forEach((key, values) -> copy.put(key, List.copyOf(values)));
+        return Map.copyOf(copy);
+    }
+
+    public static final class Builder {
+
+        private String method = "GET";
+        private URI uri;
+        private final Map<String, List<String>> headers = new LinkedHashMap<>();
+        private final Map<String, List<String>> queryParams = new LinkedHashMap<>();
+        private byte[] body;
+        private String contentType;
+        private Duration timeout;
+
+        public Builder method(String method) {
+            String normalized = Objects.requireNonNull(method, "method").trim();
+            if (normalized.isEmpty()) {
+                throw new IllegalArgumentException("method cannot be empty");
+            }
+            this.method = normalized.toUpperCase();
+            return this;
+        }
+
+        public Builder uri(String uri) {
+            return uri(URI.create(Objects.requireNonNull(uri, "uri")));
+        }
+
+        public Builder uri(URI uri) {
+            this.uri = Objects.requireNonNull(uri, "uri");
+            return this;
+        }
+
+        public Builder header(String name, String value) {
+            add(headers, name, value);
+            return this;
+        }
+
+        public Builder queryParam(String name, String value) {
+            add(queryParams, name, value);
+            return this;
+        }
+
+        public Builder body(String body) {
+            return body(body, "text/plain; charset=UTF-8");
+        }
+
+        public Builder body(String body, String contentType) {
+            Objects.requireNonNull(body, "body");
+            return body(body.getBytes(StandardCharsets.UTF_8), contentType);
+        }
+
+        public Builder body(byte[] body) {
+            return body(body, "application/octet-stream");
+        }
+
+        public Builder body(byte[] body, String contentType) {
+            this.body = Objects.requireNonNull(body, "body").clone();
+            this.contentType = Objects.requireNonNull(contentType, "contentType");
+            return this;
+        }
+
+        public Builder timeout(Duration timeout) {
+            Objects.requireNonNull(timeout, "timeout");
+            if (timeout.isZero() || timeout.isNegative()) {
+                throw new IllegalArgumentException("timeout must be positive");
+            }
+            this.timeout = timeout;
+            return this;
+        }
+
+        public HttpRequest build() {
+            if (uri == null) {
+                throw new IllegalStateException("uri is required");
+            }
+            return new HttpRequest(this);
+        }
+
+        private static void add(Map<String, List<String>> target, String name, String value) {
+            String cleanName = Objects.requireNonNull(name, "name").trim();
+            if (cleanName.isEmpty()) {
+                throw new IllegalArgumentException("name cannot be empty");
+            }
+            target.computeIfAbsent(cleanName, ignored -> new ArrayList<>())
+                    .add(Objects.requireNonNull(value, "value"));
+        }
+    }
+}

--- a/infrastructure-component-http/src/main/java/org/carl/infrastructure/http/HttpRequestContext.java
+++ b/infrastructure-component-http/src/main/java/org/carl/infrastructure/http/HttpRequestContext.java
@@ -1,0 +1,14 @@
+package org.carl.infrastructure.http;
+
+public final class HttpRequestContext {
+
+    private final HttpRequest request;
+
+    public HttpRequestContext(HttpRequest request) {
+        this.request = request;
+    }
+
+    public HttpRequest getRequest() {
+        return request;
+    }
+}

--- a/infrastructure-component-http/src/main/java/org/carl/infrastructure/http/HttpResponse.java
+++ b/infrastructure-component-http/src/main/java/org/carl/infrastructure/http/HttpResponse.java
@@ -1,0 +1,54 @@
+package org.carl.infrastructure.http;
+
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public final class HttpResponse {
+
+    private final int statusCode;
+    private final String reasonPhrase;
+    private final Map<String, List<String>> headers;
+    private final byte[] body;
+
+    public HttpResponse(int statusCode, String reasonPhrase, Map<String, List<String>> headers, byte[] body) {
+        this.statusCode = statusCode;
+        this.reasonPhrase = reasonPhrase;
+        this.headers = copyMultiMap(headers);
+        this.body = body == null ? new byte[0] : body.clone();
+    }
+
+    public int getStatusCode() {
+        return statusCode;
+    }
+
+    public String getReasonPhrase() {
+        return reasonPhrase;
+    }
+
+    public Map<String, List<String>> getHeaders() {
+        return headers;
+    }
+
+    public byte[] getBody() {
+        return body.clone();
+    }
+
+    public String getBodyAsString() {
+        return getBodyAsString(StandardCharsets.UTF_8);
+    }
+
+    public String getBodyAsString(Charset charset) {
+        return new String(body, charset);
+    }
+
+    private static Map<String, List<String>> copyMultiMap(Map<String, List<String>> source) {
+        Map<String, List<String>> copy = new LinkedHashMap<>();
+        if (source != null) {
+            source.forEach((key, values) -> copy.put(key, List.copyOf(values)));
+        }
+        return Map.copyOf(copy);
+    }
+}

--- a/infrastructure-component-http/src/main/java/org/carl/infrastructure/http/HttpResponseContext.java
+++ b/infrastructure-component-http/src/main/java/org/carl/infrastructure/http/HttpResponseContext.java
@@ -1,0 +1,20 @@
+package org.carl.infrastructure.http;
+
+public final class HttpResponseContext {
+
+    private final HttpRequest request;
+    private final HttpResponse response;
+
+    public HttpResponseContext(HttpRequest request, HttpResponse response) {
+        this.request = request;
+        this.response = response;
+    }
+
+    public HttpRequest getRequest() {
+        return request;
+    }
+
+    public HttpResponse getResponse() {
+        return response;
+    }
+}

--- a/infrastructure-component-http/src/main/java/org/carl/infrastructure/http/apache/ApacheAsyncHttpClient.java
+++ b/infrastructure-component-http/src/main/java/org/carl/infrastructure/http/apache/ApacheAsyncHttpClient.java
@@ -1,0 +1,234 @@
+package org.carl.infrastructure.http.apache;
+
+import org.apache.hc.client5.http.async.methods.SimpleHttpRequest;
+import org.apache.hc.client5.http.async.methods.SimpleHttpResponse;
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
+import org.apache.hc.client5.http.impl.async.HttpAsyncClients;
+import org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManager;
+import org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManagerBuilder;
+import org.apache.hc.core5.concurrent.FutureCallback;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.Header;
+import org.apache.hc.core5.net.URIBuilder;
+import org.apache.hc.core5.util.Timeout;
+import org.carl.infrastructure.http.HttpClient;
+import org.carl.infrastructure.http.HttpClientException;
+import org.carl.infrastructure.http.HttpClientOptions;
+import org.carl.infrastructure.http.HttpCompletionContext;
+import org.carl.infrastructure.http.HttpErrorContext;
+import org.carl.infrastructure.http.HttpInterceptor;
+import org.carl.infrastructure.http.HttpRequest;
+import org.carl.infrastructure.http.HttpRequestContext;
+import org.carl.infrastructure.http.HttpResponse;
+import org.carl.infrastructure.http.HttpResponseContext;
+import org.carl.infrastructure.logging.ILogger;
+import org.carl.infrastructure.logging.LoggerFactory;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public final class ApacheAsyncHttpClient implements HttpClient {
+
+    private static final ILogger LOGGER = LoggerFactory.getLogger(ApacheAsyncHttpClient.class);
+
+    private final HttpClientOptions options;
+    private final CloseableHttpAsyncClient client;
+    private final AtomicBoolean closed = new AtomicBoolean(false);
+
+    public ApacheAsyncHttpClient(HttpClientOptions options) {
+        this.options = Objects.requireNonNull(options, "options");
+        PoolingAsyncClientConnectionManager connectionManager =
+                PoolingAsyncClientConnectionManagerBuilder.create()
+                        .setMaxConnTotal(options.getMaxConnections())
+                        .setMaxConnPerRoute(options.getMaxConnections())
+                        .build();
+        this.client = HttpAsyncClients.custom()
+                .setConnectionManager(connectionManager)
+                .setDefaultRequestConfig(requestConfig(options.getResponseTimeout()))
+                .build();
+        this.client.start();
+    }
+
+    @Override
+    public CompletionStage<HttpResponse> execute(HttpRequest request) {
+        Objects.requireNonNull(request, "request");
+        if (closed.get()) {
+            CompletableFuture<HttpResponse> failed = new CompletableFuture<>();
+            failed.completeExceptionally(new HttpClientException("HTTP client is closed"));
+            return failed;
+        }
+
+        HttpRequestContext requestContext = new HttpRequestContext(request);
+        return runBeforeRequest(requestContext)
+                .thenCompose(ignored -> runBeforeSend(requestContext))
+                .thenCompose(ignored -> send(request))
+                .thenCompose(response -> handleSuccess(request, response))
+                .exceptionallyCompose(error -> handleFailure(request, unwrap(error)));
+    }
+
+    @Override
+    public void close() {
+        if (closed.compareAndSet(false, true)) {
+            try {
+                client.close();
+            } catch (Exception e) {
+                throw new HttpClientException("Failed to close HTTP client", e);
+            }
+        }
+    }
+
+    private CompletionStage<Void> runBeforeRequest(HttpRequestContext context) {
+        CompletionStage<Void> chain = CompletableFuture.completedFuture(null);
+        for (HttpInterceptor interceptor : options.getInterceptors()) {
+            chain = chain.thenCompose(ignored -> interceptor.beforeRequest(context));
+        }
+        return chain;
+    }
+
+    private CompletionStage<Void> runBeforeSend(HttpRequestContext context) {
+        CompletionStage<Void> chain = CompletableFuture.completedFuture(null);
+        for (HttpInterceptor interceptor : options.getInterceptors()) {
+            chain = chain.thenCompose(ignored -> interceptor.beforeSend(context));
+        }
+        return chain;
+    }
+
+    private CompletionStage<SimpleHttpResponse> send(HttpRequest request) {
+        CompletableFuture<SimpleHttpResponse> future = new CompletableFuture<>();
+        SimpleHttpRequest apacheRequest = toApacheRequest(request);
+        client.execute(apacheRequest, new FutureCallback<>() {
+            @Override
+            public void completed(SimpleHttpResponse result) {
+                future.complete(result);
+            }
+
+            @Override
+            public void failed(Exception ex) {
+                future.completeExceptionally(new HttpClientException("HTTP request failed", ex));
+            }
+
+            @Override
+            public void cancelled() {
+                future.completeExceptionally(new HttpClientException("HTTP request was cancelled"));
+            }
+        });
+        if (request.getTimeout() != null) {
+            future.orTimeout(request.getTimeout().toMillis(), TimeUnit.MILLISECONDS);
+        }
+        return future;
+    }
+
+    private CompletionStage<HttpResponse> handleSuccess(HttpRequest request, SimpleHttpResponse apacheResponse) {
+        HttpResponse response = toResponse(apacheResponse);
+        HttpResponseContext responseContext = new HttpResponseContext(request, response);
+
+        CompletionStage<Void> chain = CompletableFuture.completedFuture(null);
+        for (HttpInterceptor interceptor : options.getInterceptors()) {
+            chain = chain.thenCompose(ignored -> interceptor.afterResponseHeaders(responseContext));
+        }
+        for (HttpInterceptor interceptor : options.getInterceptors()) {
+            chain = chain.thenCompose(ignored -> interceptor.afterResponseBody(responseContext));
+        }
+        return chain.thenCompose(ignored -> afterCompletion(request, response, null))
+                .thenApply(ignored -> response);
+    }
+
+    private CompletionStage<HttpResponse> handleFailure(HttpRequest request, Throwable error) {
+        Throwable componentError = error instanceof HttpClientException
+                ? error
+                : new HttpClientException("HTTP request failed", error);
+        HttpErrorContext errorContext = new HttpErrorContext(request, componentError);
+
+        CompletionStage<Void> chain = CompletableFuture.completedFuture(null);
+        for (HttpInterceptor interceptor : options.getInterceptors()) {
+            chain = chain.thenCompose(ignored -> interceptor.onError(errorContext));
+        }
+        return chain
+                .exceptionally(onErrorFailure -> {
+                    LOGGER.warn("HTTP onError interceptor failed", unwrap(onErrorFailure));
+                    return null;
+                })
+                .thenCompose(ignored -> afterCompletion(request, null, componentError))
+                .handle((ignored, completionFailure) -> {
+                    if (completionFailure != null) {
+                        LOGGER.warn("HTTP afterCompletion interceptor failed", unwrap(completionFailure));
+                    }
+                    throw new CompletionException(componentError);
+                });
+    }
+
+    private CompletionStage<Void> afterCompletion(HttpRequest request, HttpResponse response, Throwable error) {
+        HttpCompletionContext completionContext = new HttpCompletionContext(request, response, error);
+        CompletionStage<Void> chain = CompletableFuture.completedFuture(null);
+        for (HttpInterceptor interceptor : options.getInterceptors()) {
+            chain = chain.thenCompose(ignored -> interceptor.afterCompletion(completionContext));
+        }
+        return chain;
+    }
+
+    private SimpleHttpRequest toApacheRequest(HttpRequest request) {
+        URI uri = withQueryParams(request);
+        SimpleHttpRequest apacheRequest = new SimpleHttpRequest(request.getMethod(), uri);
+        request.getHeaders().forEach((name, values) ->
+                values.forEach(value -> apacheRequest.addHeader(name, value)));
+        if (request.hasBody()) {
+            ContentType contentType = ContentType.parse(request.getContentType());
+            apacheRequest.setBody(request.getBody(), contentType);
+        }
+        if (request.getTimeout() != null) {
+            apacheRequest.setConfig(requestConfig(request.getTimeout()));
+        }
+        return apacheRequest;
+    }
+
+    private URI withQueryParams(HttpRequest request) {
+        if (request.getQueryParams().isEmpty()) {
+            return request.getUri();
+        }
+        try {
+            URIBuilder builder = new URIBuilder(request.getUri());
+            request.getQueryParams().forEach((name, values) ->
+                    values.forEach(value -> builder.addParameter(name, value)));
+            return builder.build();
+        } catch (URISyntaxException e) {
+            throw new HttpClientException("Invalid request URI", e);
+        }
+    }
+
+    private HttpResponse toResponse(SimpleHttpResponse response) {
+        Map<String, List<String>> headers = new LinkedHashMap<>();
+        for (Header header : response.getHeaders()) {
+            headers.computeIfAbsent(header.getName(), ignored -> new ArrayList<>()).add(header.getValue());
+        }
+        return new HttpResponse(
+                response.getCode(),
+                response.getReasonPhrase(),
+                headers,
+                response.getBodyBytes());
+    }
+
+    private RequestConfig requestConfig(java.time.Duration responseTimeout) {
+        return RequestConfig.custom()
+                .setConnectTimeout(Timeout.ofMilliseconds(options.getConnectTimeout().toMillis()))
+                .setResponseTimeout(Timeout.ofMilliseconds(responseTimeout.toMillis()))
+                .build();
+    }
+
+    private static Throwable unwrap(Throwable error) {
+        if (error instanceof CompletionException && error.getCause() != null) {
+            return error.getCause();
+        }
+        return error;
+    }
+}

--- a/infrastructure-component-http/src/test/java/org/carl/infrastructure/http/ApacheAsyncHttpClientTest.java
+++ b/infrastructure-component-http/src/test/java/org/carl/infrastructure/http/ApacheAsyncHttpClientTest.java
@@ -1,0 +1,230 @@
+package org.carl.infrastructure.http;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Executors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ApacheAsyncHttpClientTest {
+
+    private HttpServer server;
+    private HttpClient client;
+
+    @AfterEach
+    void tearDown() {
+        if (client != null) {
+            client.close();
+        }
+        if (server != null) {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    void executesRequestAndReturnsBodyHeadersAndStatus() throws Exception {
+        server = startServer(exchange -> {
+            assertEquals("POST", exchange.getRequestMethod());
+            assertEquals("from-test", exchange.getRequestHeaders().getFirst("X-Request-Source"));
+            assertEquals("/echo?name=carl", exchange.getRequestURI().toString());
+            String requestBody = new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8);
+            respond(exchange, 200, "text/plain", "received:" + requestBody);
+        });
+        client = HttpClientFactory.create();
+
+        HttpResponse response = client.execute(HttpRequest.post(url("/echo"))
+                        .queryParam("name", "carl")
+                        .header("X-Request-Source", "from-test")
+                        .body("hello")
+                        .build())
+                .toCompletableFuture()
+                .get();
+
+        assertEquals(200, response.getStatusCode());
+        assertEquals("received:hello", response.getBodyAsString());
+        assertEquals("text/plain", response.getHeaders().get("Content-type").getFirst());
+    }
+
+    @Test
+    void nonSuccessResponseReturnsNormally() throws Exception {
+        server = startServer(exchange -> respond(exchange, 503, "text/plain", "try later"));
+        client = HttpClientFactory.create();
+
+        HttpResponse response = client.execute(HttpRequest.get(url("/unavailable")).build())
+                .toCompletableFuture()
+                .get();
+
+        assertEquals(503, response.getStatusCode());
+        assertEquals("try later", response.getBodyAsString());
+    }
+
+    @Test
+    void interceptorOrderIsStableForSuccess() throws Exception {
+        server = startServer(exchange -> respond(exchange, 200, "text/plain", "ok"));
+        RecordingInterceptor interceptor = new RecordingInterceptor();
+        client = HttpClientFactory.create(HttpClientOptions.builder()
+                .addInterceptor(interceptor)
+                .build());
+
+        HttpResponse response = client.execute(HttpRequest.get(url("/ok")).build())
+                .toCompletableFuture()
+                .get();
+
+        assertEquals(200, response.getStatusCode());
+        assertEquals(List.of(
+                "beforeRequest",
+                "beforeSend",
+                "afterResponseHeaders",
+                "afterResponseBody",
+                "afterCompletion"
+        ), interceptor.events);
+    }
+
+    @Test
+    void interceptorOrderIsStableForTransportError() {
+        RecordingInterceptor interceptor = new RecordingInterceptor();
+        client = HttpClientFactory.create(HttpClientOptions.builder()
+                .addInterceptor(interceptor)
+                .build());
+
+        CompletionException exception = assertThrows(CompletionException.class, () ->
+                client.execute(HttpRequest.get("http://127.0.0.1:1/not-open")
+                                .timeout(Duration.ofMillis(200))
+                                .build())
+                        .toCompletableFuture()
+                        .join());
+
+        assertInstanceOf(HttpClientException.class, exception.getCause());
+        assertEquals(List.of("beforeRequest", "beforeSend", "onError", "afterCompletion"), interceptor.events);
+    }
+
+    @Test
+    void timeoutTriggersErrorLifecycle() throws Exception {
+        server = startServer(exchange -> {
+            try {
+                Thread.sleep(500);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            respond(exchange, 200, "text/plain", "slow");
+        });
+        RecordingInterceptor interceptor = new RecordingInterceptor();
+        client = HttpClientFactory.create(HttpClientOptions.builder()
+                .addInterceptor(interceptor)
+                .build());
+
+        CompletionException exception = assertThrows(CompletionException.class, () ->
+                client.execute(HttpRequest.get(url("/slow"))
+                                .timeout(Duration.ofMillis(100))
+                                .build())
+                        .toCompletableFuture()
+                        .join());
+
+        assertInstanceOf(HttpClientException.class, exception.getCause());
+        assertEquals(List.of("beforeRequest", "beforeSend", "onError", "afterCompletion"), interceptor.events);
+    }
+
+    @Test
+    void closeCanBeCalledMoreThanOnce() {
+        client = HttpClientFactory.create();
+
+        client.close();
+        client.close();
+
+        CompletionException exception = assertThrows(CompletionException.class, () ->
+                client.execute(HttpRequest.get("http://127.0.0.1:1/closed").build())
+                        .toCompletableFuture()
+                        .join());
+        assertInstanceOf(HttpClientException.class, exception.getCause());
+    }
+
+    private HttpServer startServer(ExchangeHandler handler) throws IOException {
+        HttpServer httpServer = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        httpServer.createContext("/", exchange -> {
+            try {
+                handler.handle(exchange);
+            } catch (UncheckedIOException e) {
+                throw e.getCause();
+            }
+        });
+        httpServer.setExecutor(Executors.newCachedThreadPool());
+        httpServer.start();
+        return httpServer;
+    }
+
+    private String url(String path) {
+        return "http://127.0.0.1:" + server.getAddress().getPort() + path;
+    }
+
+    private static void respond(HttpExchange exchange, int status, String contentType, String body) {
+        try (exchange) {
+            byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().set("Content-Type", contentType);
+            exchange.sendResponseHeaders(status, bytes.length);
+            exchange.getResponseBody().write(bytes);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    @FunctionalInterface
+    private interface ExchangeHandler {
+        void handle(HttpExchange exchange) throws IOException;
+    }
+
+    private static final class RecordingInterceptor implements HttpInterceptor {
+
+        private final List<String> events = new ArrayList<>();
+
+        @Override
+        public CompletionStage<Void> beforeRequest(HttpRequestContext context) {
+            events.add("beforeRequest");
+            return HttpInterceptor.super.beforeRequest(context);
+        }
+
+        @Override
+        public CompletionStage<Void> beforeSend(HttpRequestContext context) {
+            events.add("beforeSend");
+            return HttpInterceptor.super.beforeSend(context);
+        }
+
+        @Override
+        public CompletionStage<Void> afterResponseHeaders(HttpResponseContext context) {
+            events.add("afterResponseHeaders");
+            return HttpInterceptor.super.afterResponseHeaders(context);
+        }
+
+        @Override
+        public CompletionStage<Void> afterResponseBody(HttpResponseContext context) {
+            events.add("afterResponseBody");
+            return HttpInterceptor.super.afterResponseBody(context);
+        }
+
+        @Override
+        public CompletionStage<Void> onError(HttpErrorContext context) {
+            events.add("onError");
+            return HttpInterceptor.super.onError(context);
+        }
+
+        @Override
+        public CompletionStage<Void> afterCompletion(HttpCompletionContext context) {
+            events.add("afterCompletion");
+            return HttpInterceptor.super.afterCompletion(context);
+        }
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -27,6 +27,7 @@ include("infrastructure-component-embedding-grpc")
 include("infrastructure-component-dto")
 include("infrastructure-component-log")
 include("infrastructure-component-utils")
+include("infrastructure-component-http")
 
 include("infrastructure-component-mq-api")
 include("infrastructure-component-mq-pulsar")


### PR DESCRIPTION
## Summary
- Add independent infrastructure-component-http module backed by Apache HttpComponents Client 5 async internals
- Add public request/response/options/client/interceptor API under org.carl.infrastructure.http
- Cover local execution, non-2xx responses, lifecycle ordering, timeout/error flow, and idempotent close with JUnit tests

Closes BAC-144

## Verification
- ./gradlew :infrastructure-component-http:test
- ./gradlew test (fails in existing unrelated modules: rule-engine/statemachine test imports still reference com.alibaba.cola packages; redis local tests fail around Jackson generic serialization and sentinel connection)